### PR TITLE
Migrating from master and slave terminology

### DIFF
--- a/myScripts.py
+++ b/myScripts.py
@@ -991,12 +991,12 @@ def getCollocated(file1, file2, destination):
 
 		parameters = HashMap()
 		sourceProducts = HashMap()
-		sourceProducts.put("master", products[0])
-		sourceProducts.put("slave", products[1])
-		parameters.put('renameMasterComponents', True)
-		parameters.put('renameSlaveComponents', True)
-		parameters.put('masterComponentPattern', "${ORIGINAL_NAME}_M")
-		parameters.put('slaveComponentPattern', "${ORIGINAL_NAME}_S")
+		sourceProducts.put("main", products[0])
+		sourceProducts.put("subordinate", products[1])
+		parameters.put('renameMainComponents', True)
+		parameters.put('renameSubordinateComponents', True)
+		parameters.put('mainComponentPattern', "${ORIGINAL_NAME}_M")
+		parameters.put('subordinateComponentPattern', "${ORIGINAL_NAME}_S")
 		parameters.put('resamplingType', getCollocatedResamplingType)
 		
 		result = GPF.createProduct('Collocate', parameters, sourceProducts)


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.